### PR TITLE
Convert "operating instructions" to markdown.

### DIFF
--- a/operating-instructions.md
+++ b/operating-instructions.md
@@ -1,22 +1,27 @@
-User instructions for Raduino_v1.27
+## User instructions for Raduino_v1.27
 
-IMPORTANT: This sketch version requires the library "PinChangeInterrupt" for interrupt handling. Use your IDE to install
+**IMPORTANT**: This sketch version requires the library ["PinChangeInterrupt"](https://playground.arduino.cc/Main/PinChangeInterrupt) for interrupt handling. Use your IDE to install
 it before compiling this sketch.
 
 After a version update all calibration data, drive level settings, etc will be reset to 'factory' values.
 Before updating note down your cal values etc. After the update use the Function Button to set them back again.
 Without any hardware modifications the sketch provides basic LSB functionality. Depending on the user's choice,
 additional functionality provided by this software can be activated by installing the related (minimal) hardware mods.
-See the table at https://github.com/amunters/bitx40/blob/master/hardware%20modification%20overview.PNG showing which
-mods are required for each function. Details of each mod are described below.
+See the table below showing which mods are required for each function. Details of each mod are described below.
 
-10-TURN TUNING POT
+![Table of hardware modifications](https://github.com/amunters/bitx40/blob/master/hardware%20modification%20overview.PNG)
+
+## 10-TURN TUNING POT
+
 The default frequency span of the standard supplied 1-turn tuning pot is only 50 kHz.
 If you install a 10-turn pot instead you can extend the span for full 40m band coverage.
-https://github.com/amunters/bitx40/blob/master/Vishay%20100K%2C%2010-turn%20pot%20wire%20up.jpg
-Using the Function Button, go to the SETTINGS menu and set the desired pot span.
 
-FUNCTION BUTTON WIRING:
+![Image of 10-turn pot hookup](https://github.com/amunters/bitx40/blob/master/Vishay%20100K%2C%2010-turn%20pot%20wire%20up.jpg)
+
+Using the Function Button, go to the SETTINGS menu and [set the desired pot span](#tuning-range).
+
+## FUNCTION BUTTON WIRING:
+
 Connect a momentary pushbutton between pin A3 (connector P1, orange wire) and ground.
 Arduino's internal pull-up resistors are used, therefore do NOT install an external pull-up resistor!
 
@@ -26,27 +31,69 @@ If you don't install a pushbutton then the basic LSB functions will still work.
 Calibration can still be done in the old fashioned way by using the CAL button (connector P1, pin A2 - red wire).
 The tuning range setting can be 'hard coded' by editing lines 34-36 and adapting the values to your needs.
 
-PIN LAYOUT
-https://github.com/amunters/bitx40/blob/master/raduino_pin_layout.png
+## PIN LAYOUT
 
-PTT SENSE WIRING:
+![Raduino pin layout](https://github.com/amunters/bitx40/blob/master/raduino_pin_layout.png)
+
+### Connector P1 (8 pin)
+
+* A0 (black): PTTSense
+* A1 (brown): Key, "dit"
+* A2 (red): CAL
+* A3 (orange): Function Button
+* GND (yellow)
+* +5V (green)
+* A6 (blue): unused
+* A7 (purple): Tuning Pot
+
+### Connector P3 (16 pin)
+
+The first 11 pins have no headers (pads only):
+
+* D7: TX-RX
+* D6: CW Carrier
+* D5: CW Side Tone
+* D4: CW SPOT Button
+* D3: Key, "dah"
+* ??: Unused
+* ??: Unused
+* ??: Unused
+* ??: Unused
+* ??: Unused
+* ??: Unused
+
+The 5 pin header
+
+* GND (black)
+* GND (brown)
+* CLK2 (red)
+* +5V (orange)
+* ?? (yellow): Unused
+
+
+## PTT SENSE WIRING:
+
 Connect pin A0 (connector P1, black wire) via a 10K resistor to the output of U3 (LM7805 regulator) on the BITX40 board.
-See https://github.com/amunters/bitx40/blob/master/PTT%20SENSE%20wiring.png
+
+![PTT Sense wiring](https://github.com/amunters/bitx40/blob/master/PTT%20SENSE%20wiring.png)
+
 When the PTT is not pressed (RX mode), the regulator will be off, so pin A0 will see 0V (LOW).
 When the PTT is pressed (TX mode), the regulator will be on, so pin A0 will see +5V (HIGH).
 The PTT SENSE is required for the CW, RIT, SPLIT functionality, and for disabling frequency updating during TX
 (to prevent "FM-ing"). If you don't install the PTT sense, LSB and USB operation will still work normally.
 
-CONNECTING A STRAIGHT MORSE KEY or 'TUNE' BUTTON:
+## CONNECTING A STRAIGHT MORSE KEY or 'TUNE' BUTTON:
+
 A straight key (or external electronic keyer) can be connected to Raduino pin A1 (connector P1, brown wire).
-It is recommended to install a 1K series resistor to protect the Arduino input.
-When the key is up (open) pin A1 will be HIGH.
+It is recommended to install a 1K series resistor to protect the Arduino input. When the key is up (open) pin A1 will be HIGH.
 When the key is down (closed, shorted to ground) pin A1 will be LOW, and a carrier will be transmitted.
+
 You could also wire up a simple push button instead of connecting a morse key. The generated CW carrier can be used for
 tuning up your antenna. In that case please note that you will be transmitting a carrier at full duty cycle, therefore don't
 keep the tune button pressed for too long to prevent overheating the final!
 
-AUTOMATIC KEYER - CONNECTING A PADDLE:
+## AUTOMATIC KEYER - CONNECTING A PADDLE:
+
 The Raduino is set up for straight key operation by default. If you want to use the automatic keyer, go to the SETTINGS menu
 and to 'CW parameters' => 'Key-type' and select 'paddle', 'rev. paddle' (for left-handed operators), 'bug', or 'rev. bug'.
 Connect the 'dit' contact to Raduino pin A1 (connector P1, brown wire).
@@ -54,16 +101,19 @@ Connect the 'dah' contact to Raduino pin D3 (connector P3).
 It is recommended to install 1K series resistors to protect the Arduino inputs.
 The built-in keyer provides Iambic mode A and 'bug'-mode (Vibroplex emulation) functionality and the paddles can be reversed.
 
-CAPACITIVE TOUCH KEYER:
+## CAPACITIVE TOUCH KEYER:
+
 The sketch supports Capacitive Touch functionality. With this feature it is possible to use touch sensors instead of a
 mechanical morse key or paddle. Straight key as well as automatic keyer operation is possible via the touch sensors.
-See https://www.youtube.com/watch?v=9MWM6UVy9k4 for a demonstration.
+See the following demo: https://www.youtube.com/watch?v=9MWM6UVy9k4
 
-A minimal modification (add four resistors) is required for this function, for details
-see https://github.com/amunters/bitx40/blob/master/capacitive%20touch%20keyer%20modification.png
+A minimal modification (add four resistors) is required for this function.
+
+![Capacitive Touch Keyer Mod](https://github.com/amunters/bitx40/blob/master/capacitive%20touch%20keyer%20modification.png)
 
 The capacitive touch sensors are disabled by default. To enable them, go to the SETTINGS menu and to 'CW parameters' =>
 'Touch sensor', and use the tuning knob to set the desired touch sensor sensitivity.
+
 A good sensitivity value to start with is 22. Increase the value for more sensitivity. The maximum value is 25.
 The sensitivity setting is quite delicate and depends on your personal taste. The best results are usually obtained with
 high sensitivity. However, if the sensitivity is too high, the radio may be keyed by electrical noise or objects nearby
@@ -71,17 +121,22 @@ the touch pads. It may also happen that iambic keying will occur even when only 
 sensitivity if these symptons occur. On the other hand, if the sensitivity is too low, the keyer may not respond properly
 to the touch pads, for example double DITs or DAHs may be generated. Some experimentation may be required to find the optimum
 setting.
+
 The touch sensors are calibrated automatically at start up. If you want to recalibrate them, simply power OFF and ON again,
 while NOT touching the sensor pads. The sensor calibration data will be shown on the LCD display at start up.
 Note: When the touch keyer is enabled, normal paddle operation is not possible. If you want to use a standard paddle, set
 the touch sensor sensitivity to 0 (touch sensor OFF).
 
-CW-CARRIER WIRING:
+## CW-CARRIER WIRING:
+
 This is required for CW operation (or when you want to generate a carrier for tuning)
 Connect a wire from Raduino ouput D6 (connector P3, pin 15), via a 10K series resistor, to the input of the mixer.
-See https://github.com/amunters/bitx40/blob/master/CW-CARRIER%20wiring.png
+
+![CW Carrier Wiring](https://github.com/amunters/bitx40/blob/master/CW-CARRIER%20wiring.png)
+
 When the key is down ouput D6 will be HIGH. This injects some DC current into the mixer so that it becomes unbalanced.
 As a result a CW carrier will be generated.
+
 Note: If the carrier is not generated at full output power, you may need to reduce the 10K series resistor to a lower value
 for more drive. However try to keep it as high as possible to keep a clean CW signal. Never use a resistor less than 1K!
 Extra tip: For tuning purposes a reduced carrier is usually desired. You can optionally connect a 100K pot in series with the
@@ -90,17 +145,23 @@ Extra tip: For tuning purposes a reduced carrier is usually desired. You can opt
 The CW-CARRIER is only required for CW functionality. If you don't install this line everything else
 will still work normally.
 
-CW SIDE TONE WIRING:
+## CW SIDE TONE WIRING:
+
 A side tone is available at Raduino output D5 (connector P3, pin 14). This signal can be fed to the speaker/headphones
 in parallel to the output from the existing audio amplifier.
-See https://github.com/amunters/bitx40/blob/master/sidetone%20wiring.png
+
+![CW Side Tone Wiring](https://github.com/amunters/bitx40/blob/master/sidetone%20wiring.png)
+
 The desired side tone pitch can be set using the Function Button in the SETTINGS menu.
 The CW-side tone is only used for CW operation. If you don't install this line everything else
 will still work normally.
 
-TX-RX WIRING:
-See https://github.com/amunters/bitx40/blob/master/TX-RX%20line%20wiring.png
+## TX-RX WIRING:
+
+![TX-RX Wiring](https://github.com/amunters/bitx40/blob/master/TX-RX%20line%20wiring.png)
+
 This is required for CW operation.
+
 When the key is down output D7 (connector P3, pin 15) will be HIGH. It will only go LOW again when the key has been up for at
 least 350 ms (this timeout value can be changed via the SETTINGS menu).
 This signal is used to drive an NPN transistor which is connected in parallel to the existing PTT switch, so that it will
@@ -109,12 +170,14 @@ bypass the PTT switch during CW operation. As as result the relays will be activ
 back of it).
 (The PTT bypass transistor may be used in the future for VOX functionality as well).
 
-CW SPOT/FINE TUNE Button:
+## CW SPOT/FINE TUNE Button:
+
 Connect a momentary pushbutton between pin D4 (connector P3) and ground.
 Arduino's internal pull-up resistors are used, therefore do NOT install an external pull-up resistor!
 When operating CW it is important that both stations transmit their carriers on the same frequency.
 When the SPOT button is pressed while the radio is in RX mode, the RIT will be turned off and the sidetone will be generated
 (but no carrier will be transmitted).
+
 While the SPOT button is held pressed, the radio will temporarily go into "FINE TUNE" mode, allowing the VFO to be set at 1Hz 
 precision. This feature works also in SSB mode (except that no sidetone will be generated then).
 Tune the tuning pot so that the pitch of the received CW signal is equal to the pitch of the CW Spot tone.
@@ -123,33 +186,42 @@ the other station's signal to be exactly on the same frequency (zero beat).
 (The SPOT button is just an extra tuning aid and is not strictly required for CW - if you don't install it, CW operation is
 still possible).
 
-DIAL LOCK FUNCTION
+## DIAL LOCK FUNCTION
+
 Press the Function Button and then the SPOT button simultanuously to lock the dial.
 When the dial is locked tuning will be disabled, PTT and CW is still possible.
 Press the Function Button again to unlock.
 
-SPURIOUS BURST PREVENTION
+## SPURIOUS BURST PREVENTION
+
 In order to prevent that a spurious burst is emitted when switching from RX to TX, a short delay (TX_DELAY) is applied.
 By default the TX_DELAY is set to 65 ms. The delay time can be adjusted by editing line 71 as necessary.
 
-FUNCTION BUTTON USAGE:
+## FUNCTION BUTTON USAGE:
 
 Several functions are available with just one pushbutton.
 Certain menu options will not appear when the related hardware mods are not installed.
 
-In normal operation mode:
-1 short press - toggle VFO A/B
-2 short presses - RIT on (PTT sense is required for this function) (press FB again to switch RIT off)
-3 short presses - toggle SPLIT on/off (PTT sense is required for this function)
-4 short presses - switch mode (rotate through LSB-USB-CWL-CWU)
-5 short presses - start frequency SCAN mode
-6 short presses - start VFO A/B monitoring mode
-long press (> 1 second) - VFO A=B
+### Operating Mode
 
-When you press the Fbutton VERY long (>3 seconds) you will enter the SETTINGS menu.
-In the SETTINGS menu:
+In normal operation mode:
+
+* 1 short press - toggle VFO A/B
+* 2 short presses - RIT on (PTT sense is required for this function) (press FB again to switch RIT off)
+* 3 short presses - toggle SPLIT on/off (PTT sense is required for this function)
+* 4 short presses - switch mode (rotate through LSB-USB-CWL-CWU)
+* 5 short presses - start frequency SCAN mode
+* 6 short presses - start VFO A/B monitoring mode
+* long press (> 1 second) - VFO A=B
+
+
+### Settings Mode
+
+To enter SETTINGS menu, press and hold the Function Button for a VERY long (>3 seconds).
  
-1 short press - set frequency SCAN parameters (lower limit, upper limit, step size, step delay)
+#### Frequency Scan
+
+1 short press sets frequency SCAN parameters (lower limit, upper limit, step size, step delay)
 
  - using the tuning pot, set the desired lower frequency scan limit
  - press the FB
@@ -159,7 +231,9 @@ In the SETTINGS menu:
  - press the FB
  - using the tuning pot, set the desired scan step delay (also used for A/B monitoring mode)
  - press the FB again to save the settings
- 
+
+#### CW Configuration
+
 2 short presses - set CW paramaters (sidetone pitch, CW-key type, semiQSK on/off, QSK delay)
    (only available when PTTsense line is installed)
 
@@ -177,6 +251,8 @@ In the SETTINGS menu:
  - using the tuning pot, set the desired sidetone pitch
  - press the FB
 
+#### VFO Calibration, LSB
+
 3 short presses - VFO frequency calibration in LSB mode
 
   - use another transceiver to generate a carrier at a known frequency (for example 7100.0 kHz)
@@ -186,6 +262,8 @@ In the SETTINGS menu:
   - go into the LSB calibration mode (3 short press)
   - using the tuning pot, adjust the correction value (ppm) for exactly zero beat
   - press the Function Button again to save the setting
+
+#### VFO Calibration, USB
   
 4 short presses - VFO frequency calibration in USB mode
 
@@ -197,6 +275,8 @@ In the SETTINGS menu:
   - go into the USB calibration mode (4 short presses)
   - using the tuning pot, adjust the USB offset for exactly zero beat
   - press the Function Button again to save the setting
+
+#### VFO Drive Level, LSB
   
 5 short presses - set VFO drive level in LSB mode
 
@@ -205,7 +285,9 @@ In the SETTINGS menu:
   - the default drive level in LSB mode is 4mA
   - using the tuning pot, try different drive levels (2,4,6,8 mA) to minimize the strength of the birdie
   - press the FB again to save the setting
-  
+
+#### VFO Drive Level, USB  
+
 6 short presses - set VFO drive level in USB mode
 
   - tune to a weak signal
@@ -217,6 +299,8 @@ In the SETTINGS menu:
   These caps attenuate the VFO signal at higher frequencies. They're actually only needed for the analog VFO
   and can safely be removed if you use the Raduino DDS instead of the analog VFO.
 
+#### Tuning Range
+
 7 short presses - set tuning range (min frequency, max frequency, pot span)
 
   - using the tuning pot, set the minimum tuning frequency and press the FB
@@ -227,29 +311,34 @@ In the SETTINGS menu:
     recommended value: 50 kHz for a 1-turn pot, 200 kHz for a 10-turn pot
     (if the radio is mainly used for CW: a pot span of 10-25 kHz is recommended)
   - press the FB again to save the setting
+
+#### Exit Settings
  
-long press (>1 second) - return to the NORMAL mode
+One long press (>1 second) will exit the SETTINGs menu and return to normal [operating mode](#operating-mode)
 
 All user settings are stored in EEPROM and retrieved during startup.
 
-When you keep the Fbutton pressed during power on all user settings will be erased and set back to "factory" values:
-VFO calibration value: 0
-VFO calibration offset (USB): 1500 Hz
-VFO drive level (LSB): 4mA
-VFO drive level (USB): 8mA
-Minimum frequency: 7000 kHz
-Maximum frequency: 7300 kHz
-Tuning pot span: 50 kHz
-Mode LSB for both VFO A and B
-CW side tone: 800 Hz
-CW key-type: Straight key
-Touch sensors: OFF
-Auto-space: OFF
-semiQSK: ON
-QSK delay: 350 ms
-Lower scan limit: 7100 kHz
-Upper scan limit: 7150 kHz
-Scan step: 1 kHz
-Scan step delay: 500 ms
+### Factory Settings
+
+To reset all used settings to "factory" values, press and hold the Function button during power on. The factory settings are:
+
+* VFO calibration value: 0
+* VFO calibration offset (USB): 1500 Hz
+* VFO drive level (LSB): 4mA
+* VFO drive level (USB): 8mA
+* Minimum frequency: 7000 kHz
+* Maximum frequency: 7300 kHz
+* Tuning pot span: 50 kHz
+* Mode LSB for both VFO A and B
+* CW side tone: 800 Hz
+* CW key-type: Straight key
+* Touch sensors: OFF
+* Auto-space: OFF
+* semiQSK: ON
+* QSK delay: 350 ms
+* Lower scan limit: 7100 kHz
+* Upper scan limit: 7150 kHz
+* Scan step: 1 kHz
+* Scan step delay: 500 ms
 
 A warning message "VFO uncalibrated" will be displayed until you recalibrate the VFO again.


### PR DESCRIPTION
Convert the operating instructions file be Markdown formatted. This will allow Github to render the file as nicely formatted HTML with links, images, lists, etc. 