### PR TITLE
PlatformIO layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.pioenvs
+.piolibdeps
+.clang_complete
+.gcc-flags.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+# Continuous Integration (CI) is the practice, in software
+# engineering, of merging all developer working copies with a shared mainline
+# several times a day < http://docs.platformio.org/page/ci/index.html >
+#
+# Documentation:
+#
+# * Travis CI Embedded Builds with PlatformIO
+#   < https://docs.travis-ci.com/user/integration/platformio/ >
+#
+# * PlatformIO integration with Travis CI
+#   < http://docs.platformio.org/page/ci/travis.html >
+#
+# * User Guide for `platformio ci` command
+#   < http://docs.platformio.org/page/userguide/cmd_ci.html >
+#
+#
+# Please choice one of the following templates (proposed below) and uncomment
+# it (remove "# " before each line) or use own configuration according to the
+# Travis CI documentation (see above).
+#
+
+
+#
+# Template #1: General project. Test it using existing `platformio.ini`.
+#
+
+# language: python
+# python:
+#     - "2.7"
+#
+# sudo: false
+# cache:
+#     directories:
+#         - "~/.platformio"
+#
+# install:
+#     - pip install -U platformio
+#
+# script:
+#     - platformio run
+
+
+#
+# Template #2: The project is intended to by used as a library with examples
+#
+
+# language: python
+# python:
+#     - "2.7"
+#
+# sudo: false
+# cache:
+#     directories:
+#         - "~/.platformio"
+#
+# env:
+#     - PLATFORMIO_CI_SRC=path/to/test/file.c
+#     - PLATFORMIO_CI_SRC=examples/file.ino
+#     - PLATFORMIO_CI_SRC=path/to/test/directory
+#
+# install:
+#     - pip install -U platformio
+#
+# script:
+#     - platformio ci --lib="." --board=ID_1 --board=ID_2 --board=ID_N

--- a/bitx40.ino
+++ b/bitx40.ino
@@ -1,0 +1,5 @@
+#include "src/main.h"
+
+extern void setup();
+extern void loop();
+

--- a/lib/readme.txt
+++ b/lib/readme.txt
@@ -1,0 +1,36 @@
+
+This directory is intended for the project specific (private) libraries.
+PlatformIO will compile them to static libraries and link to executable file.
+
+The source code of each library should be placed in separate directory, like
+"lib/private_lib/[here are source files]".
+
+For example, see how can be organized `Foo` and `Bar` libraries:
+
+|--lib
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |- readme.txt --> THIS FILE
+|- platformio.ini
+|--src
+   |- main.c
+
+Then in `src/main.c` you should use:
+
+#include <Foo.h>
+#include <Bar.h>
+
+// rest H/C/CPP code
+
+PlatformIO will find your libraries automatically, configure preprocessor's
+include paths and build them.
+
+More information about PlatformIO Library Dependency Finder
+- http://docs.platformio.org/page/librarymanager/ldf.html

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,16 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[env:nanoatmega328]
+platform = atmelavr
+board = nanoatmega328
+framework = arduino
+lib_deps =
+  PinChangeInterrupt@1.2.4

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,9 @@
    switching the CAL wire to ground.
 */
 
+#include <Arduino.h>
+#include "main.h"
+
 // *** USER PARAMETERS ***
 
 // tuning range parameters

--- a/src/main.h
+++ b/src/main.h
@@ -1,0 +1,23 @@
+#include <Arduino.h>
+
+void shiftBase();
+void setFrequency();
+void save_frequency();
+void set_CWparams();
+void set_tune_range();
+void set_drive_level(byte level);
+void calibrate_touch_pads();
+void SetSideBand(byte drivelevel);
+void VFOdrive();
+void scan_params();
+void toggleRIT();
+void toggleMode();
+void toggleSPLIT();
+void resetVFOs();
+void swapVFOs();
+int knob_position();
+
+void si5351bx_init();
+void si5351bx_setfreq(uint8_t clknum, uint32_t fout);
+void i2cWrite(uint8_t reg, uint8_t val);
+void i2cWriten(uint8_t reg, uint8_t *vals, uint8_t vcnt);


### PR DESCRIPTION
This PR reorganizes the source files to make the repo compatible with PlatformIO. It also creates a Arduino sketch with the same name as the directory which is a requirement of the Arduino IDE.

With thing change I can:
* Open "bitx40.ino" with Arduino IDE and compile/upload the Raduino (just like today). No need to "copy the sketch into a folder of the same name"
* Open as a PlatformIO project and compile/upload to the Raduino

What this allows:
* Development in PlatformIO (many nice things about this compared to Arduino IDE)
* Eventual refactoring of large sketch into smaller private libraries
* Easier writing of unit tests and integration with TravisCI

At first, I tried pulling the Si5351 code into a project-local library (which is supported by PlatformIO), but couldn't get it working via the INO sketch. Something to do with `#include` and my lacking C skills.

Is this something people would be interested in?